### PR TITLE
 feat(frontend): Refactor layout and create admin layout

### DIFF
--- a/resources/views/components/admin-layout.blade.php
+++ b/resources/views/components/admin-layout.blade.php
@@ -1,0 +1,3 @@
+<div>
+    @include('admin.layouts.app', ['slot' => $slot, 'header' => $header ?? null])
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,36 +1,44 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="scroll-smooth">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+    <!-- Judul Halaman Dinamis -->
+    <title>@yield('title', 'Kampus Medical Care')</title>
 
-        <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
-    </head>
-    <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
-            @include('layouts.navigation')
+    <!-- Memuat Tailwind CSS via CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Scripts -->
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 
-            <!-- Page Heading -->
-            @isset($header)
-                <header class="bg-white dark:bg-gray-800 shadow">
-                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                        {{ $header }}
-                    </div>
-                </header>
-            @endisset
+    <!-- Memuat Font Inter (standar Tailwind) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 
-            <!-- Page Content -->
-            <main>
-                {{ $slot }}
-            </main>
-        </div>
-    </body>
+    <style>
+        /* Menggunakan font Inter sebagai default */
+        body {
+            font-family: 'poppins', sans-serif;
+        }
+    </style>
+</head>
+
+<body class="bg-gray-50 text-gray-800">
+
+    <!-- Memuat Navbar PUBLIK (bukan navigasi admin) -->
+    @include('partials.navbar')
+
+    <!-- Konten Halaman Utama -->
+    <main>
+        @yield('content')
+    </main>
+
+    <!-- Memuat Footer -->
+    @include('partials.footer')
+
+</body>
+
 </html>


### PR DESCRIPTION
   - Refactor the main app.blade.php layout to serve as the primary layout for public-facing pages.
   - Create a new admin-layout.blade.php component to encapsulate the admin panel's layout, separating it from
     the main application layout.
   - Update the main layout to include a public navbar and footer.
   - Standardize fonts and switch to using Tailwind CSS via CDN for the public layout.